### PR TITLE
Add Gesture Recognizer missing on AddViewController

### DIFF
--- a/VIPER-SWIFT/Classes/Modules/Add/User Interface/View/AddViewController.swift
+++ b/VIPER-SWIFT/Classes/Modules/Add/User Interface/View/AddViewController.swift
@@ -34,7 +34,7 @@ class AddViewController: UIViewController, UITextFieldDelegate, AddViewInterface
         gestureRecognizer.addTarget(self, action: Selector("dismiss"))
         
         transitioningBackgroundView.userInteractionEnabled = true
-        
+        transitioningBackgroundView.addGestureRecognizer(gestureRecognizer)
         nameTextField.becomeFirstResponder()
         
         if let realDatePicker = datePicker {


### PR DESCRIPTION
Minor mistake that was lost in the Swift translation. Gesture Recognizer should be added to the transitioning background view for the AddViewController. It is correct in the Objective C version of the app.
