### PR TITLE
Updated for swift 2.2 syntax

### DIFF
--- a/VIPER-SWIFT.xcodeproj/project.pbxproj
+++ b/VIPER-SWIFT.xcodeproj/project.pbxproj
@@ -520,7 +520,9 @@
 		261FA1461941497E0029F589 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastSwiftMigration = 0730;
+				LastSwiftUpdateCheck = 0730;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Conrad Stoll";
 				TargetAttributes = {
 					261FA14D1941497E0029F589 = {
@@ -677,9 +679,11 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -719,6 +723,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -742,8 +747,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = "VIPER-SWIFT/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mutualmobile.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -753,8 +760,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = "VIPER-SWIFT/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mutualmobile.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -774,6 +783,7 @@
 				INFOPLIST_FILE = "VIPER-SWIFTTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mutualmobile.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 			};
@@ -790,6 +800,7 @@
 				INFOPLIST_FILE = "VIPER-SWIFTTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mutualmobile.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 			};

--- a/VIPER-SWIFT/Base.lproj/Main.storyboard
+++ b/VIPER-SWIFT/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6154.17" systemVersion="14A238x" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="F64-Qc-pGf">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="F64-Qc-pGf">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6153.11"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -35,7 +36,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="empty" translatesAutoresizingMaskIntoConstraints="NO" id="IUm-Nr-pH8">
+                        <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" image="empty" translatesAutoresizingMaskIntoConstraints="NO" id="IUm-Nr-pH8">
                             <rect key="frame" x="80" y="204" width="160" height="160"/>
                         </imageView>
                     </subviews>
@@ -48,24 +49,24 @@
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="Dwl-V3-Jpn">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <prototypes>
-                        <tableViewCell contentMode="scaleToFill" ambiguous="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListEntryCell" textLabel="NBj-2E-azl" detailTextLabel="1oT-NU-IFa" style="IBUITableViewCellStyleValue1" id="Rhp-dv-i8T">
-                            <rect key="frame" x="0.0" y="55" width="320" height="44"/>
+                        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListEntryCell" textLabel="NBj-2E-azl" detailTextLabel="1oT-NU-IFa" style="IBUITableViewCellStyleValue1" id="Rhp-dv-i8T">
+                            <rect key="frame" x="0.0" y="49.5" width="320" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Rhp-dv-i8T" id="gVg-IG-mur">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
                                     <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NBj-2E-azl">
-                                        <rect key="frame" x="15" y="11" width="33" height="21"/>
+                                        <rect key="frame" x="15" y="12" width="33.5" height="20.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1oT-NU-IFa">
-                                        <rect key="frame" x="261" y="11" width="44" height="21"/>
+                                        <rect key="frame" x="261" y="12" width="44" height="20.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
@@ -119,7 +120,7 @@
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Todo" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yGG-G0-t38">
                                 <rect key="frame" x="40" y="49" width="74" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XfR-vQ-kf1">
@@ -133,7 +134,7 @@
                             <datePicker contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="gW8-Uc-U23">
                                 <rect key="frame" x="0.0" y="102" width="260" height="162"/>
                                 <date key="date" timeIntervalSinceReferenceDate="422464776.95016199">
-                                    <!--<__NSDate Class=2014-05-22 15:19:36 +0000 timeInterval=422464776.950162 ISO8601=2014-05-22T08:19:36.950-0700>-->
+                                    <!--2014-05-22 15:19:36 +0000-->
                                 </date>
                             </datePicker>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Due Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hIS-VJ-zb9">
@@ -172,10 +173,5 @@
         <image name="month" width="25" height="25"/>
         <image name="notes" width="25" height="25"/>
     </resources>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
     <color key="tintColor" red="0.86274516582489014" green="0.48627454042434692" blue="0.39215689897537231" alpha="1" colorSpace="deviceRGB"/>
 </document>

--- a/VIPER-SWIFT/Classes/AppDelegate.swift
+++ b/VIPER-SWIFT/Classes/AppDelegate.swift
@@ -13,10 +13,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     let appDependencies = AppDependencies()
-
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    
+    
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         appDependencies.installRootViewControllerIntoWindow(window!)
-        
         return true
     }
 }

--- a/VIPER-SWIFT/Classes/Common/Categories/NSCalendar+CalendarAdditions.swift
+++ b/VIPER-SWIFT/Classes/Common/Categories/NSCalendar+CalendarAdditions.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension NSCalendar {
     class func gregorianCalendar() -> NSCalendar {
-        return NSCalendar(calendarIdentifier: NSGregorianCalendar)
+        return NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)!
     }
     
     func dateWithYear(year: Int, month: Int, day: Int) -> NSDate {
@@ -19,40 +19,39 @@ extension NSCalendar {
         components.month = month
         components.day = day
         components.hour = 12
-        return dateFromComponents(components)
+        return dateFromComponents(components)!
     }
     
     func dateForTomorrowRelativeToToday(today: NSDate) -> NSDate {
         let tomorrowComponents = NSDateComponents()
         tomorrowComponents.day = 1
-        return dateByAddingComponents(tomorrowComponents, toDate: today, options: nil)
+        return dateByAddingComponents(tomorrowComponents, toDate: today, options: NSCalendarOptions.MatchFirst)!
     }
     
     func dateForEndOfWeekWithDate(date: NSDate) -> NSDate {
         let daysRemainingThisWeek = daysRemainingInWeekWithDate(date)
         let remainingDaysComponent = NSDateComponents()
         remainingDaysComponent.day = daysRemainingThisWeek
-        return dateByAddingComponents(remainingDaysComponent, toDate: date, options: nil)
+        return dateByAddingComponents(remainingDaysComponent, toDate: date, options: NSCalendarOptions.MatchFirst)!
     }
     
     func dateForBeginningOfDay(date: NSDate) -> NSDate {
-        let newComponent = components((NSCalendarUnit.YearCalendarUnit | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitDay), fromDate: date)
+        let newComponent = components([.Year, .Month, .Day], fromDate: date)
         let newDate = dateFromComponents(newComponent)
-        return newDate
+        return newDate!
     }
     
     func dateForEndOfDay(date: NSDate) -> NSDate {
         let components = NSDateComponents()
         components.day = 1
         let toDate = dateForBeginningOfDay(date)
-        let nextDay = dateByAddingComponents(components, toDate: toDate, options: nil)
-        let endDay = nextDay.dateByAddingTimeInterval(-1)
-        return nextDay
+        let nextDay = dateByAddingComponents(components, toDate: toDate, options: [])
+        return nextDay!
     }
     
     func daysRemainingInWeekWithDate(date: NSDate) -> Int {
-        let weekdayComponent = components(NSCalendarUnit.WeekdayCalendarUnit, fromDate: date)
-        let daysRange = rangeOfUnit(NSCalendarUnit.WeekdayCalendarUnit, inUnit: NSCalendarUnit.WeekCalendarUnit, forDate: date)
+        let weekdayComponent = components([.Weekday], fromDate: date)
+        let daysRange = rangeOfUnit(.Weekday, inUnit: .WeekOfYear, forDate: date)
         let daysPerWeek = daysRange.length
         let daysRemaining = daysPerWeek - weekdayComponent.weekday
         return daysRemaining
@@ -61,9 +60,9 @@ extension NSCalendar {
     func dateForEndOfFollowingWeekWithDate(date: NSDate) -> NSDate {
         let endOfWeek = dateForEndOfWeekWithDate(date)
         let nextWeekComponent = NSDateComponents()
-        nextWeekComponent.setWeek(1)
-        let followingWeekDate = dateByAddingComponents(nextWeekComponent, toDate: endOfWeek, options: nil)
-        return followingWeekDate
+        nextWeekComponent.setValue(1, forComponent: NSCalendarUnit.WeekOfYear)
+        let followingWeekDate = dateByAddingComponents(nextWeekComponent, toDate: endOfWeek, options: [])
+        return followingWeekDate!
     }
     
     func isDate(date: NSDate, beforeYearMonthDay: NSDate) -> Bool {
@@ -79,17 +78,17 @@ extension NSCalendar {
     }
     
     func isDate(date: NSDate, duringSameWeekAsDate: NSDate) -> Bool {
-        let dateComponents = components(NSCalendarUnit.WeekCalendarUnit, fromDate: date)
-        let duringSameWeekComponents = components(NSCalendarUnit.WeekCalendarUnit, fromDate: duringSameWeekAsDate)
-        let result = dateComponents.week() == duringSameWeekComponents.week()
+        let dateComponents = components(.WeekOfYear, fromDate: date)
+        let duringSameWeekComponents = components(.WeekOfYear, fromDate: duringSameWeekAsDate)
+        let result = dateComponents.weekOfYear == duringSameWeekComponents.weekOfYear
         return result
     }
     
     func isDate(date: NSDate, duringWeekAfterDate: NSDate) -> Bool {
         let nextWeek = dateForEndOfFollowingWeekWithDate(duringWeekAfterDate)
-        let dateComponents = components(NSCalendarUnit.WeekCalendarUnit, fromDate: date)
-        let nextWeekComponents = components(NSCalendarUnit.WeekCalendarUnit, fromDate: nextWeek)
-        let result = dateComponents.week() == nextWeekComponents.week()
+        let dateComponents = components(.WeekOfYear, fromDate: date)
+        let nextWeekComponents = components(.WeekOfYear, fromDate: nextWeek)
+        let result = dateComponents.weekOfYear == nextWeekComponents.weekOfYear
         return result
     }
     
@@ -111,7 +110,7 @@ extension NSCalendar {
     }
     
     func yearMonthDayComponentsFromDate(date: NSDate) -> NSDateComponents {
-        let newComponents = components((NSCalendarUnit.YearCalendarUnit | NSCalendarUnit.CalendarUnitMonth | NSCalendarUnit.CalendarUnitDay), fromDate: date)
+        let newComponents = components(([.Year, .Month, .Day]), fromDate: date)
         return newComponents
     }
     

--- a/VIPER-SWIFT/Classes/Common/Store/CoreDataStore.swift
+++ b/VIPER-SWIFT/Classes/Common/Store/CoreDataStore.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreData
 
 extension Array {
-    func lastObject() -> T {
+    func lastObject() -> Element {
         let endIndex = self.endIndex
         let lastItemIndex = endIndex - 1
         
@@ -23,21 +23,20 @@ class CoreDataStore : NSObject {
     var managedObjectModel : NSManagedObjectModel?
     var managedObjectContext : NSManagedObjectContext?
     
-    init() {
+    override init() {
         managedObjectModel = NSManagedObjectModel.mergedModelFromBundles(nil)
         
-        persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
+        persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel!)
         
         let domains = NSSearchPathDomainMask.UserDomainMask
         let directory = NSSearchPathDirectory.DocumentDirectory
         
-        let error = NSError()
         let applicationDocumentsDirectory : AnyObject = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: domains).lastObject()
         let options = [NSMigratePersistentStoresAutomaticallyOption : true, NSInferMappingModelAutomaticallyOption : true]
         
         let storeURL = applicationDocumentsDirectory.URLByAppendingPathComponent("VIPER-SWIFT.sqlite")
         
-        persistentStoreCoordinator!.addPersistentStoreWithType(NSSQLiteStoreType, configuration: "", URL: storeURL, options: options, error: nil)
+        try? persistentStoreCoordinator!.addPersistentStoreWithType(NSSQLiteStoreType, configuration: "", URL: storeURL, options: options)
 
         managedObjectContext = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.MainQueueConcurrencyType)
         managedObjectContext!.persistentStoreCoordinator = persistentStoreCoordinator
@@ -46,26 +45,29 @@ class CoreDataStore : NSObject {
         super.init()
     }
     
-    func fetchEntriesWithPredicate(predicate: NSPredicate, sortDescriptors: AnyObject[], completionBlock: ((ManagedTodoItem[]) -> Void)!) {
+    func fetchEntriesWithPredicate(predicate: NSPredicate, sortDescriptors: [AnyObject], completionBlock: (([ManagedTodoItem]) -> Void)!) {
         let fetchRequest = NSFetchRequest(entityName: "TodoItem")
         fetchRequest.predicate = predicate
         fetchRequest.sortDescriptors = []
         
         managedObjectContext?.performBlock {
-            let queryResults = self.managedObjectContext?.executeFetchRequest(fetchRequest, error: nil)
-            let managedResults = queryResults! as ManagedTodoItem[]
+            let queryResults = try? self.managedObjectContext?.executeFetchRequest(fetchRequest)
+            let managedResults = queryResults! as! [ManagedTodoItem]
             completionBlock(managedResults)
         }
     }
     
     func newTodoItem() -> ManagedTodoItem {
-        let entityDescription = NSEntityDescription.entityForName("TodoItem", inManagedObjectContext: managedObjectContext)
-        let newEntry = NSManagedObject(entity: entityDescription, insertIntoManagedObjectContext: managedObjectContext) as ManagedTodoItem
+        let entityDescription = NSEntityDescription.entityForName("TodoItem", inManagedObjectContext: managedObjectContext!)
+        let newEntry = NSManagedObject(entity: entityDescription!, insertIntoManagedObjectContext: managedObjectContext) as! ManagedTodoItem
         
         return newEntry
     }
     
     func save() {
-        managedObjectContext?.save(nil)
+        do {
+            try managedObjectContext?.save()
+        } catch _ {
+        }
     }
 }

--- a/VIPER-SWIFT/Classes/Common/View/RootWireframe.swift
+++ b/VIPER-SWIFT/Classes/Common/View/RootWireframe.swift
@@ -16,7 +16,7 @@ class RootWireframe : NSObject {
     }
     
     func navigationControllerFromWindow(window: UIWindow) -> UINavigationController {
-        let navigationController = window.rootViewController as UINavigationController
+        let navigationController = window.rootViewController as! UINavigationController
         return navigationController
     }
 }

--- a/VIPER-SWIFT/Classes/Modules/Add/Application Logic/Interactor/AddInteractor.swift
+++ b/VIPER-SWIFT/Classes/Modules/Add/Application Logic/Interactor/AddInteractor.swift
@@ -12,7 +12,7 @@ class AddInteractor : NSObject {
     var addDataManager : AddDataManager?
     
     func saveNewEntryWithName(name: NSString, dueDate: NSDate) {
-        let newEntry = TodoItem(dueDate: dueDate, name: name)
+        let newEntry = TodoItem(dueDate: dueDate, name: name as String)
         addDataManager?.addNewEntry(newEntry)
     }
 }

--- a/VIPER-SWIFT/Classes/Modules/Add/Application Logic/Manager/AddDataManager.swift
+++ b/VIPER-SWIFT/Classes/Modules/Add/Application Logic/Manager/AddDataManager.swift
@@ -12,7 +12,7 @@ class AddDataManager : NSObject {
     var dataStore : CoreDataStore?
     
     func addNewEntry(entry: TodoItem) {
-        let newEntry = dataStore?.newTodoItem() as ManagedTodoItem
+        let newEntry = (dataStore?.newTodoItem())! as ManagedTodoItem
         newEntry.name = entry.name
         newEntry.date = entry.dueDate;
         

--- a/VIPER-SWIFT/Classes/Modules/Add/User Interface/Transition/AddDismissalTransition.swift
+++ b/VIPER-SWIFT/Classes/Modules/Add/User Interface/Transition/AddDismissalTransition.swift
@@ -10,12 +10,13 @@ import Foundation
 import UIKit
 
 class AddDismissalTransition : NSObject, UIViewControllerAnimatedTransitioning {
-    func transitionDuration(transitionContext: UIViewControllerContextTransitioning!) -> NSTimeInterval {
+    
+    func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
         return 0.72
     }
 
-    func animateTransition(transitionContext: UIViewControllerContextTransitioning!) {
-        let fromVC = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey) as AddViewController
+    func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+        let fromVC = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey) as! AddViewController
         
         let finalCenter = CGPointMake(160.0, (fromVC.view.bounds.size.height / 2) - 1000.0)
         

--- a/VIPER-SWIFT/Classes/Modules/Add/User Interface/Transition/AddPresentationTransition.swift
+++ b/VIPER-SWIFT/Classes/Modules/Add/User Interface/Transition/AddPresentationTransition.swift
@@ -10,21 +10,23 @@ import Foundation
 import UIKit
 
 class AddPresentationTransition: NSObject, UIViewControllerAnimatedTransitioning {
-    func transitionDuration(transitionContext: UIViewControllerContextTransitioning!) -> NSTimeInterval {
+    func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
         return 0.72
     }
     
-    func animateTransition(transitionContext: UIViewControllerContextTransitioning!) {
-        let fromVC = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey)
-        let toVC = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey) as AddViewController
+    func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
+        guard let fromVC = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey),
+            toVC = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey) as? AddViewController else {
+                return
+        }
         
         toVC.transitioningBackgroundView.backgroundColor = UIColor.darkGrayColor()
         toVC.transitioningBackgroundView.alpha = 0.0
         toVC.transitioningBackgroundView.frame = UIScreen.mainScreen().bounds
         
         let containerView = transitionContext.containerView()
-        containerView.addSubview(toVC.transitioningBackgroundView)
-        containerView.addSubview(toVC.view)
+        containerView?.addSubview(toVC.transitioningBackgroundView)
+        containerView?.addSubview(toVC.view)
         
         let toViewFrame = CGRectMake(0, 0, 260, 300)
         toVC.view.frame = toViewFrame

--- a/VIPER-SWIFT/Classes/Modules/Add/User Interface/View/AddViewController.swift
+++ b/VIPER-SWIFT/Classes/Modules/Add/User Interface/View/AddViewController.swift
@@ -12,14 +12,14 @@ import UIKit
 class AddViewController: UIViewController, UITextFieldDelegate, AddViewInterface {
     var eventHandler : AddModuleInterface?
 
-    @IBOutlet var nameTextField : UITextField
-    @IBOutlet var datePicker : UIDatePicker?
+    @IBOutlet var nameTextField : UITextField!
+    @IBOutlet var datePicker : UIDatePicker!
     
     var minimumDate : NSDate = NSDate()
     var transitioningBackgroundView : UIView = UIView()
     
     @IBAction func save(sender: AnyObject) {
-        eventHandler?.saveAddActionWithName(nameTextField.text, dueDate: datePicker!.date)
+        eventHandler?.saveAddActionWithName(nameTextField.text!, dueDate: datePicker!.date)
     }
     
     @IBAction func cancel(sender: AnyObject) {
@@ -30,8 +30,8 @@ class AddViewController: UIViewController, UITextFieldDelegate, AddViewInterface
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
         
-        var gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.addTarget(self, action: Selector("dismiss"))
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.addTarget(self, action: #selector(AddViewController.dismiss))
         
         transitioningBackgroundView.userInteractionEnabled = true
         
@@ -53,7 +53,7 @@ class AddViewController: UIViewController, UITextFieldDelegate, AddViewInterface
     }
     
     func setEntryName(name: NSString) {
-        nameTextField.text = name
+        nameTextField.text = name as String
     }
     
     func setEntryDueDate(date: NSDate) {
@@ -70,7 +70,7 @@ class AddViewController: UIViewController, UITextFieldDelegate, AddViewInterface
         }
     }
     
-    func textFieldShouldReturn(textField: UITextField!) -> Bool {
+    func textFieldShouldReturn(textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         
         return true

--- a/VIPER-SWIFT/Classes/Modules/Add/User Interface/Wireframe/AddWireframe.swift
+++ b/VIPER-SWIFT/Classes/Modules/Add/User Interface/Wireframe/AddWireframe.swift
@@ -35,7 +35,7 @@ class AddWireframe : NSObject, UIViewControllerTransitioningDelegate {
     
     func addViewController() -> AddViewController {
         let storyboard = mainStoryboard()
-        let addViewController: AddViewController = storyboard.instantiateViewControllerWithIdentifier(AddViewControllerIdentifier) as AddViewController
+        let addViewController: AddViewController = storyboard.instantiateViewControllerWithIdentifier(AddViewControllerIdentifier) as! AddViewController
         return addViewController
     }
     
@@ -44,11 +44,11 @@ class AddWireframe : NSObject, UIViewControllerTransitioningDelegate {
         return storyboard
     }
     
-    func animationControllerForDismissedController(dismissed: UIViewController!) -> UIViewControllerAnimatedTransitioning! {
+    func animationControllerForDismissedController(dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return AddDismissalTransition()
     }
     
-   func animationControllerForPresentedController(presented: UIViewController!, presentingController presenting: UIViewController!, sourceController source: UIViewController!) -> UIViewControllerAnimatedTransitioning! {
+   func animationControllerForPresentedController(presented: UIViewController, presentingController presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return AddPresentationTransition()
     }
 }

--- a/VIPER-SWIFT/Classes/Modules/List/Application Logic/Interactor/ListInteractor.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/Application Logic/Interactor/ListInteractor.swift
@@ -31,13 +31,13 @@ class ListInteractor : NSObject, ListInteractorInput {
         })
     }
     
-    func upcomingItemsFromToDoItems(todoItems: TodoItem[]) -> UpcomingItem[] {
+    func upcomingItemsFromToDoItems(todoItems: [TodoItem]) -> [UpcomingItem] {
         let calendar = NSCalendar.autoupdatingCurrentCalendar()
         
-        var upcomingItems : UpcomingItem[] = []
+        var upcomingItems : [UpcomingItem] = []
         
         for todoItem in todoItems {
-            var dateRelation = calendar.nearTermRelationForDate(todoItem.dueDate, relativeToToday: clock.today())
+            let dateRelation = calendar.nearTermRelationForDate(todoItem.dueDate, relativeToToday: clock.today())
             let upcomingItem = UpcomingItem(title: todoItem.name, dueDate: todoItem.dueDate, dateRelation: dateRelation)
             upcomingItems.insert(upcomingItem, atIndex: upcomingItems.endIndex)
         }

--- a/VIPER-SWIFT/Classes/Modules/List/Application Logic/Interactor/ListInteractorIO.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/Application Logic/Interactor/ListInteractorIO.swift
@@ -14,5 +14,5 @@ protocol ListInteractorInput {
 }
 
 protocol ListInteractorOutput {
-    func foundUpcomingItems(upcomingItems: UpcomingItem[])
+    func foundUpcomingItems(upcomingItems: [UpcomingItem])
 }

--- a/VIPER-SWIFT/Classes/Modules/List/Application Logic/Interactor/UpcomingItem.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/Application Logic/Interactor/UpcomingItem.swift
@@ -9,10 +9,15 @@
 import Foundation
 
 struct UpcomingItem : Equatable {
-    let title : String = ""
-    let dueDate : NSDate = NSDate()
-    let dateRelation : NearTermDateRelation = NearTermDateRelation.OutOfRange
+    let title: String
+    let dueDate: NSDate
+    let dateRelation: NearTermDateRelation
     
+    init() {
+        self.title = ""
+        dueDate = NSDate()
+        dateRelation = NearTermDateRelation.OutOfRange
+    }
     init(title: String, dueDate: NSDate, dateRelation: NearTermDateRelation) {
         self.title = title
         self.dueDate = dueDate

--- a/VIPER-SWIFT/Classes/Modules/List/Application Logic/Manager/ListDataManager.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/Application Logic/Manager/ListDataManager.swift
@@ -12,7 +12,7 @@ import Foundation
 class ListDataManager : NSObject {
     var coreDataStore : CoreDataStore?
 
-    func todoItemsBetweenStartDate(startDate: NSDate, endDate: NSDate, completion: ((TodoItem[]) -> Void)!) {
+    func todoItemsBetweenStartDate(startDate: NSDate, endDate: NSDate, completion: (([TodoItem]) -> Void)!) {
         let calendar = NSCalendar.autoupdatingCurrentCalendar()
         let beginning = calendar.dateForBeginningOfDay(startDate)
         let end = calendar.dateForEndOfDay(endDate)
@@ -21,18 +21,18 @@ class ListDataManager : NSObject {
         let sortDescriptors = []
         
         coreDataStore?.fetchEntriesWithPredicate(predicate,
-            sortDescriptors: sortDescriptors,
+            sortDescriptors: sortDescriptors as [AnyObject],
             completionBlock: { entries in
                 let todoItems = self.todoItemsFromDataStoreEntries(entries)
                 completion(todoItems)
         })
     }
     
-    func todoItemsFromDataStoreEntries(entries: ManagedTodoItem[]) -> TodoItem[] {
-        var todoItems : TodoItem[] = []
+    func todoItemsFromDataStoreEntries(entries: [ManagedTodoItem]) -> [TodoItem] {
+        var todoItems : [TodoItem] = []
         
         for managedTodoItem in entries {
-            let todoItem = TodoItem(dueDate: managedTodoItem.date, name: managedTodoItem.name)
+            let todoItem = TodoItem(dueDate: managedTodoItem.date, name: managedTodoItem.name as String)
             todoItems.append(todoItem)
         }
         

--- a/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/ListPresenter.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/ListPresenter.swift
@@ -18,7 +18,7 @@ class ListPresenter : NSObject, ListInteractorOutput, ListModuleInterface, AddMo
         listInteractor?.findUpcomingItems()
     }
     
-    func foundUpcomingItems(upcomingItems: UpcomingItem[]) {
+    func foundUpcomingItems(upcomingItems: [UpcomingItem]) {
         if upcomingItems.count == 0 {
             userInterface?.showNoContentMessage()
         } else {
@@ -26,12 +26,12 @@ class ListPresenter : NSObject, ListInteractorOutput, ListModuleInterface, AddMo
         }
     }
     
-    func updateUserInterfaceWithUpcomingItems(upcomingItems: UpcomingItem[]) {
+    func updateUserInterfaceWithUpcomingItems(upcomingItems: [UpcomingItem]) {
         let upcomingDisplayData = upcomingDisplayDataWithItems(upcomingItems)
         userInterface?.showUpcomingDisplayData(upcomingDisplayData)
     }
     
-    func upcomingDisplayDataWithItems(upcomingItems: UpcomingItem[]) -> UpcomingDisplayData {
+    func upcomingDisplayDataWithItems(upcomingItems: [UpcomingItem]) -> UpcomingDisplayData {
         let collection = UpcomingDisplayDataCollection()
         collection.addUpcomingItems(upcomingItems)
         return collection.collectedDisplayData()

--- a/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/UpcomingDisplayData.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/UpcomingDisplayData.swift
@@ -9,11 +9,13 @@
 import Foundation
 
 struct UpcomingDisplayData : Equatable {
-    let sections : UpcomingDisplaySection[] = []
+    let sections : [UpcomingDisplaySection]
     
-    init(sections: UpcomingDisplaySection[]) {
+    init() {
+        self.sections = []
+    }
+    init(sections: [UpcomingDisplaySection]) {
         self.sections = sections
-        self.sections.unshare()
     }
 }
 

--- a/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/UpcomingDisplayDataCollection.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/UpcomingDisplayDataCollection.swift
@@ -10,29 +10,29 @@ import Foundation
 
 class UpcomingDisplayDataCollection {
     let dayFormatter = NSDateFormatter()
-    var sections : Dictionary<NearTermDateRelation, UpcomingDisplayItem[]> = Dictionary()
+    var sections : Dictionary<NearTermDateRelation, [UpcomingDisplayItem]> = Dictionary()
     
     init() {
         dayFormatter.dateFormat = NSDateFormatter.dateFormatFromTemplate("EEEE", options: 0, locale: NSLocale.autoupdatingCurrentLocale())
     }
     
-    func addUpcomingItems(upcomingItems: UpcomingItem[]) {
+    func addUpcomingItems(upcomingItems: [UpcomingItem]) {
         for upcomingItem in upcomingItems {
             addUpcomingItem(upcomingItem)
         }
     }
     
     func addUpcomingItem(upcomingItem: UpcomingItem) {
-        var displayItem = displayItemForUpcomingItem(upcomingItem)
+        let displayItem = displayItemForUpcomingItem(upcomingItem)
         addDisplayItem(displayItem, dateRelation: upcomingItem.dateRelation)
     }
     
     func addDisplayItem(displayItem: UpcomingDisplayItem, dateRelation: NearTermDateRelation) {
-        if var realSection : UpcomingDisplayItem[] = sections[dateRelation] {
+        if var realSection : [UpcomingDisplayItem] = sections[dateRelation] {
             realSection.append(displayItem)
             sections[dateRelation] = realSection
         } else {
-            var newSection : UpcomingDisplayItem[] = []
+            var newSection : [UpcomingDisplayItem] = []
             newSection.append(displayItem)
             sections[dateRelation] = newSection
         }
@@ -53,7 +53,7 @@ class UpcomingDisplayDataCollection {
     }
     
     func collectedDisplayData() -> UpcomingDisplayData {
-        let collectedSections : UpcomingDisplaySection[] = sortedUpcomingDisplaySections()
+        let collectedSections : [UpcomingDisplaySection] = sortedUpcomingDisplaySections()
         return UpcomingDisplayData(sections: collectedSections)
     }
     
@@ -65,15 +65,15 @@ class UpcomingDisplayDataCollection {
         return UpcomingDisplaySection(name: sectionTitle, imageName: imageName, items: items)
     }
     
-    func sortedUpcomingDisplaySections() -> UpcomingDisplaySection[] {
+    func sortedUpcomingDisplaySections() -> [UpcomingDisplaySection] {
         let keys = sortedNearTermDateRelations()
-        var displaySections : UpcomingDisplaySection[] = []
+        var displaySections : [UpcomingDisplaySection] = []
         
         for dateRelation in keys {
-            var itemArray = sections[dateRelation]
+            let itemArray = sections[dateRelation]
             
-            if itemArray {
-                var displaySection = displaySectionForDateRelation(dateRelation)
+            if (itemArray != nil) {
+                let displaySection = displaySectionForDateRelation(dateRelation)
                 displaySections.insert(displaySection, atIndex: displaySections.endIndex)
             }
         }
@@ -81,8 +81,8 @@ class UpcomingDisplayDataCollection {
         return displaySections
     }
     
-    func sortedNearTermDateRelations() -> NearTermDateRelation[] {
-        var array : NearTermDateRelation[] = []
+    func sortedNearTermDateRelations() -> [NearTermDateRelation] {
+        var array : [NearTermDateRelation] = []
         array.insert(NearTermDateRelation.Today, atIndex: 0)
         array.insert(NearTermDateRelation.Tomorrow, atIndex: 1)
         array.insert(NearTermDateRelation.LaterThisWeek, atIndex: 2)

--- a/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/UpcomingDisplayItem.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/UpcomingDisplayItem.swift
@@ -8,14 +8,18 @@
 
 import Foundation
 
-struct UpcomingDisplayItem : Equatable, Printable {
-    let title : String = ""
-    let dueDate : String = ""
+struct UpcomingDisplayItem : Equatable, CustomStringConvertible {
+    let title: String
+    let dueDate: String
     
     var description : String { get {
         return "\(title) -- \(dueDate)"
     }}
     
+    init() {
+        self.title = ""
+        self.dueDate = ""
+    }
     init(title: String, dueDate: String) {
         self.title = title
         self.dueDate = dueDate

--- a/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/UpcomingDisplaySection.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/User Interface/Presenter/UpcomingDisplaySection.swift
@@ -10,17 +10,16 @@
 import Foundation
 
 struct UpcomingDisplaySection : Equatable {
-    let name : String = ""
-    let imageName : String = ""
-    var items : UpcomingDisplayItem[] = []
+    let name : String
+    let imageName : String
+    var items : [UpcomingDisplayItem] = []
     
-    init(name: String, imageName: String, items: UpcomingDisplayItem[]?) {
+    init(name: String, imageName: String, items: [UpcomingDisplayItem]?) {
         self.name = name
         self.imageName = imageName
         
-        if items {
-            self.items = items!
-            self.items.unshare()
+        if let actualItems = items {
+            self.items = actualItems
         }
     }
 }

--- a/VIPER-SWIFT/Classes/Modules/List/User Interface/View/ListViewController.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/User Interface/View/ListViewController.swift
@@ -16,7 +16,7 @@ class ListViewController : UITableViewController, ListViewInterface {
     var dataProperty : UpcomingDisplayData?
     var strongTableView : UITableView?
     
-    @IBOutlet var noContentView : UIView
+    @IBOutlet var noContentView : UIView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,7 +34,7 @@ class ListViewController : UITableViewController, ListViewInterface {
     func configureView() {
         navigationItem.title = "VIPER TODO"
         
-        let addItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Add, target: self, action: Selector("didTapAddButton"))
+        let addItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Add, target: self, action: #selector(ListViewController.didTapAddButton))
         
         navigationItem.rightBarButtonItem = addItem
     }
@@ -58,7 +58,7 @@ class ListViewController : UITableViewController, ListViewInterface {
         tableView.reloadData()
     }
     
-    override func numberOfSectionsInTableView(tableView: UITableView!) -> Int {
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         var numberOfSections = dataProperty?.sections.count
         
         if dataProperty?.sections.count == nil {
@@ -68,25 +68,25 @@ class ListViewController : UITableViewController, ListViewInterface {
         return numberOfSections!
     }
     
-    override func tableView(tableView: UITableView!, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let upcomingSection = dataProperty?.sections[section]
         return upcomingSection!.items.count
     }
     
-    override func tableView(tableView: UITableView!, titleForHeaderInSection section: Int) -> String! {
+    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String {
         let upcomingSection = dataProperty?.sections[section]
         return upcomingSection!.name
     }
     
-    override func tableView(tableView: UITableView!, cellForRowAtIndexPath indexPath: NSIndexPath!) -> UITableViewCell! {
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let upcomingSection = dataProperty?.sections[indexPath.section]
         let upcomingItem = upcomingSection!.items[indexPath.row]
         
         let cell = tableView.dequeueReusableCellWithIdentifier(ListEntryCellIdentifier, forIndexPath: indexPath) as UITableViewCell
         
-        cell.textLabel.text = upcomingItem.title;
-        cell.detailTextLabel.text = upcomingItem.dueDate;
-        cell.imageView.image = UIImage(named: upcomingSection!.imageName)
+        cell.textLabel!.text = upcomingItem.title;
+        cell.detailTextLabel!.text = upcomingItem.dueDate;
+        cell.imageView!.image = UIImage(named: upcomingSection!.imageName)
         cell.selectionStyle = UITableViewCellSelectionStyle.None;
 
         return cell

--- a/VIPER-SWIFT/Classes/Modules/List/User Interface/Wireframe/ListWireframe.swift
+++ b/VIPER-SWIFT/Classes/Modules/List/User Interface/Wireframe/ListWireframe.swift
@@ -31,7 +31,7 @@ class ListWireframe : NSObject {
     
     func listViewControllerFromStoryboard() -> ListViewController {
         let storyboard = mainStoryboard()
-        let viewController = storyboard.instantiateViewControllerWithIdentifier(ListViewControllerIdentifier) as ListViewController
+        let viewController = storyboard.instantiateViewControllerWithIdentifier(ListViewControllerIdentifier) as! ListViewController
         return viewController
     }
     

--- a/VIPER-SWIFT/Info.plist
+++ b/VIPER-SWIFT/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mutualmobile.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/VIPER-SWIFTTests/CalendarTests.swift
+++ b/VIPER-SWIFTTests/CalendarTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 
 class CalendarTests: XCTestCase {
-    var calendar = NSCalendar()
+    var calendar: NSCalendar!
 
     override func setUp() {
         super.setUp()

--- a/VIPER-SWIFTTests/Info.plist
+++ b/VIPER-SWIFTTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mutualmobile.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/VIPER-SWIFTTests/RelativeDateTests.swift
+++ b/VIPER-SWIFTTests/RelativeDateTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 
 class RelativeDateTests: XCTestCase {
-    var calendar = NSCalendar()
+    var calendar: NSCalendar!
     
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
I've updated the project to use Swift 2.2 syntax.  I also made a slight change to the unit tests to make them runnable (had to change the NSCalendar property on the tests to be of type "NSCalendar!").

I figure this update will be helpful for anyone (like myself) that happens to find the article on the VIPER architecture now and want to try loading up the sample Swift project with the updates to Swift.
